### PR TITLE
Allow install time for a cryptography version without a pre-built wheel

### DIFF
--- a/artifacts/requirements.txt
+++ b/artifacts/requirements.txt
@@ -1,7 +1,24 @@
-# Requirements for the Greengrass component. Only select pre-compiled wheels for cryptography
-# to ensure we don't need Rust compiler installed on the target device. (We select the newest
-# version for which there is a wheel in piwheels.org). Only install 
-# python-pkcs11 on Linux since HSMs are only supported by Greengrass on Linux.
+# Requirements for the Greengrass component. 
+#
+# In general, we prefer to use the latest version of cryptography for which pre-built
+# wheels exist, including the Raspberry Pi (https://piwheels.org/project/cryptography/).
+#
+# However, if you elect to use a version for which no pre-built wheel exists
+# for your target device, then the first deployment of this component will build
+# the wheel. This build requires that the Rust compiler be already installed on the
+# target core device before deploying the certificate rotator component. 
+# 
+# If you need to install Rust on your target core device, please use the rustup 
+# installer (https://rustup.rs/) and take care to install Rust for your Greengrass
+# user (usually ggc_user). For example:
+#
+# sudo su ggc_user
+# curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+#
+# The Rust installation also then needs to added to your asystem path. This can be
+# done by adding /home/ggc_user/.cargo/bin to the secure_path variable in the
+# /etc/sudoers file.
+
 asn1crypto==1.5.1
 awsiotsdk==1.17.0
 cryptography==40.0.1

--- a/deploy_component_version.py
+++ b/deploy_component_version.py
@@ -93,7 +93,7 @@ def wait_for_deployment_to_finish(deploy_id):
     done = False
     snapshot = time.time()
 
-    while not done and (time.time() - snapshot) < 300:
+    while not done and (time.time() - snapshot) < 900:
         try:
             response = greengrassv2_client.get_deployment(deploymentId=deploy_id)
             deployment_status = response['deploymentStatus']

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -42,6 +42,9 @@ Manifests:
     os: linux
   Lifecycle:
     Install:
+      # If the Python cryptography package wheel has to be built, the install
+      # can take several minutes. Normally though, we use a pre-built wheel. 
+      Timeout: 900
       Script: |-
         echo Creating virtual environment
         python3 -m venv venv
@@ -73,6 +76,9 @@ Manifests:
     os: windows
   Lifecycle:
     Install:
+      # If the Python cryptography package wheel has to be built, the install
+      # can take several minutes. Normally though, we use a pre-built wheel. 
+      Timeout: 900
       Script: >-
         echo Creating virtual environment &
         python -m venv venv &

--- a/tests/test_deploy_component_version.py
+++ b/tests/test_deploy_component_version.py
@@ -147,7 +147,7 @@ def test_fails_if_job_execution_timed_out(boto3_client, job_description):
 def test_fails_if_deployment_times_out(mocker, boto3_client, job_description):
     """ Should exit abruptly if the deployment times out """
     job_description['job']['jobProcessDetails']['numberOfInProgressThings'] = 10
-    mocker.patch('time.time', side_effect=[0, 0, 300])
+    mocker.patch('time.time', side_effect=[0, 0, 900])
     job_description['job']['jobProcessDetails']['numberOfTimedOutThings'] = 1
     confirm_exit()
     calls=[call(deploymentId=DEPLOYMENT_ID), call(deploymentId=NEW_DEPLOYMENT_ID)]


### PR DESCRIPTION
*Issue #, if available:*

#19 

*Description of changes:*

Make the component install timeouts long enough to cope with building the Python wheels

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
