### PR TITLE
Handle subscribe timeout for Nucleus >= 2.10

### DIFF
--- a/artifacts/pubsub.py
+++ b/artifacts/pubsub.py
@@ -36,11 +36,12 @@ class PubSub():
         """ Subscribes to an IoT Core topic """
         print(f'Subscribing to topic {topic}')
         try:
-            self._ipc_client.subscribe_to_iot_core(topic_name=topic,
-                                                    qos=QOS.AT_LEAST_ONCE,
-                                                    on_stream_event=self.on_stream_event,
-                                                    on_stream_error=self.on_stream_error,
-                                                    on_stream_closed=self.on_stream_closed)
+            (fut, _) = self._ipc_client.subscribe_to_iot_core_async(topic_name=topic,
+                                                                    qos=QOS.AT_LEAST_ONCE,
+                                                                    on_stream_event=self.on_stream_event,
+                                                                    on_stream_error=self.on_stream_error,
+                                                                    on_stream_closed=self.on_stream_closed)
+            fut.result(timeout=30)
             rval = True
         except Exception:
             traceback.print_exc()

--- a/artifacts/state_machine.py
+++ b/artifacts/state_machine.py
@@ -57,7 +57,7 @@ class StateMachine():
 
         rollback = False
 
-        while not self._create_subscriptions() and not rollback:
+        while not rollback and not self._create_subscriptions():
             # We failed to subscribe. It means we don't have
             # comms with IoT Core, just after Greengrass has started up. If we
             # have a certificate backup, it means we are trying to rotate the

--- a/tests/artifacts/test_pubsub.py
+++ b/tests/artifacts/test_pubsub.py
@@ -49,10 +49,11 @@ def test_publish_exception(ipc_client, pubsub):
     assert pubsub.publish(TOPIC, PAYLOAD) is False
     ipc_client.publish_to_iot_core.assert_called_once_with(topic_name=TOPIC, qos=QOS.AT_MOST_ONCE, payload=PAYLOAD)
 
-def test_subscribe(ipc_client, pubsub):
+def test_subscribe(mocker, ipc_client, pubsub):
     """ Confirm subscribe """
+    ipc_client.subscribe_to_iot_core_async.return_value = (mocker.Mock(), None)
     assert pubsub.subscribe(TOPIC) is True
-    ipc_client.subscribe_to_iot_core.assert_called_once_with(topic_name=TOPIC, qos=QOS.AT_LEAST_ONCE,
+    ipc_client.subscribe_to_iot_core_async.assert_called_once_with(topic_name=TOPIC, qos=QOS.AT_LEAST_ONCE,
                                                     on_stream_event=ANY,
                                                     on_stream_error=ANY,
                                                     on_stream_closed=ANY)
@@ -61,7 +62,7 @@ def test_subscribe_exception(ipc_client, pubsub):
     """ Confirm subscribe catches exception """
     ipc_client.subscribe_to_iot_core.side_effect=Exception('mocked error')
     assert pubsub.subscribe(TOPIC) is False
-    ipc_client.subscribe_to_iot_core.assert_called_once_with(topic_name=TOPIC, qos=QOS.AT_LEAST_ONCE,
+    ipc_client.subscribe_to_iot_core_async.assert_called_once_with(topic_name=TOPIC, qos=QOS.AT_LEAST_ONCE,
                                                     on_stream_event=ANY,
                                                     on_stream_error=ANY,
                                                     on_stream_closed=ANY)


### PR DESCRIPTION
*Issue #, if available:*

#21 Rollback does not occur when using Nucleus versions 2.10 or later

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
