### PR TITLE
GH-27 JobExecutionTerminal rule filters certificate rotation jobs explicity

### DIFF
--- a/artifacts/state_getting_job.py
+++ b/artifacts/state_getting_job.py
@@ -25,7 +25,7 @@ class StateGettingJob(State):
             if message['execution']['status'] == 'QUEUED':
                 # There is a new rotation job (created before we started up)
                 topic = f'{TOPIC_BASE_JOBS}/{message["execution"]["jobId"]}/update'
-                request = { 'status': 'IN_PROGRESS' }
+                request = { 'status': 'IN_PROGRESS', 'statusDetails': { 'certificateRotationProgress': 'started' } }
                 self._context.change_state(StateUpdatingJob)
                 self._context.publish(topic, json.dumps(request))
             elif message['execution']['status'] == 'IN_PROGRESS':

--- a/artifacts/state_idle.py
+++ b/artifacts/state_idle.py
@@ -19,7 +19,7 @@ class StateIdle(State):
             and message['execution']['jobDocument']['operation'] == 'ROTATE_CERTIFICATE':
 
             topic = f'{TOPIC_BASE_JOBS}/{message["execution"]["jobId"]}/update'
-            request = { 'status': 'IN_PROGRESS' }
+            request = { 'status': 'IN_PROGRESS', 'statusDetails': { 'certificateRotationProgress': 'started' } }
             self._context.change_state(StateUpdatingJob)
             self._context.publish(topic, json.dumps(request))
 

--- a/backend/lambda/commit_certificate/commit_certificate.py
+++ b/backend/lambda/commit_certificate/commit_certificate.py
@@ -24,8 +24,8 @@ def valid_job_execution(job_execution):
     return job_execution is not None and job_execution['status'] == 'IN_PROGRESS' and\
             job_execution['jobDocument'] == os.environ.get('JOB_DOCUMENT') and\
             'statusDetails' in job_execution and len(job_execution['statusDetails']) == 3 and\
-            'progress' in job_execution['statusDetails'] and\
-            job_execution['statusDetails']['progress'] == 'created' and\
+            'certificateRotationProgress' in job_execution['statusDetails'] and\
+            job_execution['statusDetails']['certificateRotationProgress'] == 'created' and\
             'oldCertificateId' in job_execution['statusDetails'] and\
             'newCertificateId' in job_execution['statusDetails']
 
@@ -76,7 +76,7 @@ def handler(event, context):
 
         # Mark in the status details that we committed to the new certificate
         status_details = job_execution['statusDetails']
-        status_details['progress'] = 'committed'
+        status_details['certificateRotationProgress'] = 'committed'
 
         # Update the job execution with the committed status
         iot_jobs_data.update_job_execution(jobId=event['jobId'],

--- a/backend/lambda/create_certificate/create_certificate.py
+++ b/backend/lambda/create_certificate/create_certificate.py
@@ -25,7 +25,9 @@ def valid_job_execution(iot_jobs_data, event):
     # The Thing should have an IN_PROGRESS job execution with no status details
     return job_execution is not None and job_execution['status'] == 'IN_PROGRESS' and\
             job_execution['jobDocument'] == os.environ.get('JOB_DOCUMENT') and\
-            ('statusDetails' not in job_execution or len(job_execution['statusDetails']) == 0)
+            'statusDetails' in job_execution and len(job_execution['statusDetails']) == 1 and\
+            'certificateRotationProgress' in job_execution['statusDetails'] and\
+            job_execution['statusDetails']['certificateRotationProgress'] == 'started'
 
 
 def valid_thing_principals(thing_principals):
@@ -138,7 +140,7 @@ def create_certificate(iot, iot_jobs_data, event, thing_principals):
 
         # We'll remember the certificate IDs in the job execution status details
         status_details = {
-            'progress': 'created',
+            'certificateRotationProgress': 'created',
             'oldCertificateId': event['principal'],
             'newCertificateId': cert_response['certificateId']
         }

--- a/backend/lambda/job_execution_terminal/job_execution_terminal.py
+++ b/backend/lambda/job_execution_terminal/job_execution_terminal.py
@@ -93,8 +93,8 @@ def get_rotation_progress(event):
     """ Gets the progress indicator from the status details of the job execution """
     progress = None
 
-    if 'statusDetails' in event and 'progress' in event['statusDetails']:
-        progress = event['statusDetails']['progress']
+    if 'statusDetails' in event and 'certificateRotationProgress' in event['statusDetails']:
+        progress = event['statusDetails']['certificateRotationProgress']
 
     return progress
 

--- a/backend/lib/certificate-rotator-stack.ts
+++ b/backend/lib/certificate-rotator-stack.ts
@@ -49,7 +49,7 @@ export class CertificateRotatorStack extends cdk.Stack {
     this.createRule('CommitCertificate', commitCertificateLambda, 
                     `SELECT *, topic(3) AS thingName, topic() as topic, clientid() AS clientId, principal() AS principal FROM 'awslabs/things/+/certificate/commit'`)
     this.createRule('JobExecutionTerminal', jobExecutionTerminalLambda, 
-                    `SELECT * FROM '$aws/events/jobExecution/#' WHERE isUndefined(get(statusDetails, 'detailed-deployment-status')) = true`)
+                    `SELECT * FROM '$aws/events/jobExecution/#' WHERE isUndefined(statusDetails.certificateRotationProgress) = false`)
 
     this.createJobExecutionEventsCustomResource()
   }

--- a/robot/libs/Greengrass.py
+++ b/robot/libs/Greengrass.py
@@ -167,7 +167,8 @@ class Greengrass():
                 response = self._iot_jobs_data_client.describe_job_execution(jobId=job_id, thingName=thing)
                 execution = response['execution']
                 if execution['status'] == 'IN_PROGRESS' and 'statusDetails' in execution and\
-                    'progress' in execution['statusDetails'] and execution['statusDetails']['progress'] == 'created':
+                    'certificateRotationProgress' in execution['statusDetails'] and\
+                    execution['statusDetails']['certificateRotationProgress'] == 'created':
                     self._logger.info('Deactivating new certificate for: %s', thing)
                     certificate_id = execution['statusDetails']['newCertificateId']
                     self._iot_client.update_certificate(certificateId=certificate_id, newStatus='INACTIVE')

--- a/tests/artifacts/test_state_getting_job.py
+++ b/tests/artifacts/test_state_getting_job.py
@@ -31,6 +31,9 @@ def test_transition_to_state_updating_job(state_machine, state_getting_job):
     """ Confirm that transition to StateUpdatingJob occurs """
     message = create_message('QUEUED')
     state_getting_job.on_rx_message(f'{TOPIC_BASE_JOBS}/{message["execution"]["jobId"]}/get/accepted', message)
+    expected_publish_msg = { 'status': 'IN_PROGRESS', 'statusDetails': { 'certificateRotationProgress': 'started' } }
+    state_machine.publish.assert_called_once_with(f'{TOPIC_BASE_JOBS}/{message["execution"]["jobId"]}/update',
+                                                    json.dumps(expected_publish_msg))
     state_machine.change_state.assert_called_once_with(StateUpdatingJob)
 
 def test_transition_to_state_creating_certificate(state_machine, state_getting_job):

--- a/tests/artifacts/test_state_idle.py
+++ b/tests/artifacts/test_state_idle.py
@@ -27,8 +27,9 @@ def test_transition_to_state_updating_job(state_machine, state_idle):
 
     state_idle.on_rx_message(f'{TOPIC_BASE_JOBS}/notify-next', message)
 
+    expected_publish_msg = { 'status': 'IN_PROGRESS', 'statusDetails': { 'certificateRotationProgress': 'started' } }
     state_machine.publish.assert_called_once_with(f'{TOPIC_BASE_JOBS}/{message["execution"]["jobId"]}/update',
-                                                    json.dumps({ 'status': 'IN_PROGRESS' }))
+                                                    json.dumps(expected_publish_msg))
     state_machine.change_state.assert_called_once_with(StateUpdatingJob)
 
 def test_non_job_topic_is_ignored(state_machine, state_idle):

--- a/tests/backend/test_lambda_commit_certificate.py
+++ b/tests/backend/test_lambda_commit_certificate.py
@@ -27,7 +27,7 @@ def fixture_job_execution():
             'statusDetails': {
                 'newCertificateId': NEW_CERT_ID,
                 'oldCertificateId': OLD_CERT_ID,
-                'progress': 'created'
+                'certificateRotationProgress': 'created'
             },
             'jobDocument': JOB_DOCUMENT
         }
@@ -73,7 +73,7 @@ def confirm_succeeded(boto3_client):
                                                               statusDetails={
                                                                     'newCertificateId': NEW_CERT_ID,
                                                                     'oldCertificateId': OLD_CERT_ID,
-                                                                    'progress': 'committed'
+                                                                    'certificateRotationProgress': 'committed'
                                                                 })
     boto3_client.publish.assert_called_once_with(topic=f'{TOPIC}/accepted', qos=0, payload=json.dumps({}))
 
@@ -113,13 +113,13 @@ def test_commit_failed_job_execution_no_status_details(boto3_client, event, job_
 
 def test_commit_failed_job_execution_status_details_no_progress(boto3_client, event, job_execution):
     """ Commit fails if the job execution status details is missing the progress field """
-    del job_execution['execution']['statusDetails']['progress']
+    del job_execution['execution']['statusDetails']['certificateRotationProgress']
     handler(event, None)
     confirm_failed(boto3_client)
 
 def test_commit_failed_job_execution_wrong_progress(boto3_client, event, job_execution):
     """ Commit fails if the job execution has status details with wrong progress """
-    job_execution['execution']['statusDetails']['progress'] = 'something else'
+    job_execution['execution']['statusDetails']['certificateRotationProgress'] = 'something else'
     handler(event, None)
     confirm_failed(boto3_client)
 

--- a/tests/backend/test_lambda_create_certificate.py
+++ b/tests/backend/test_lambda_create_certificate.py
@@ -30,6 +30,9 @@ def fixture_job_execution():
         'execution' : {
             'jobId': JOB_ID,
             'status': 'IN_PROGRESS',
+            'statusDetails': {
+                'certificateRotationProgress': 'started'
+            },
             'jobDocument': JOB_DOCUMENT
         }
     }
@@ -99,7 +102,7 @@ def confirm_succeeded(boto3_client, event, principals):
                                                               statusDetails={
                                                                     'newCertificateId': NEW_CERT_ID,
                                                                     'oldCertificateId': OLD_CERT_ID,
-                                                                    'progress': 'created'
+                                                                    'certificateRotationProgress': 'created'
                                                                 })
     boto3_client.publish.assert_called_once_with(topic=f'{TOPIC}/accepted', qos=0,
                                                  payload=json.dumps({ 'certificatePem': NEW_CERT_PEM }))

--- a/tests/backend/test_lambda_job_execution_terminal.py
+++ b/tests/backend/test_lambda_job_execution_terminal.py
@@ -39,7 +39,7 @@ def fixture_event(mocker, boto3_client, principals):
         'status': 'SUCCEEDED',
         'statusDetails': {
             'newCertificateId': NEW_CERT_ID,
-            'progress': 'committed',
+            'certificateRotationProgress': 'committed',
             'oldCertificateId': OLD_CERT_ID
         }
     }
@@ -156,7 +156,7 @@ def test_wrong_job_document(boto3_client, event):
 def test_job_failed_after_create(boto3_client, event):
     """ This is a standard rollback. The new certificate should be deleted """
     event['status'] = 'FAILED'
-    event['statusDetails']['progress'] = 'created'
+    event['statusDetails']['certificateRotationProgress'] = 'created'
     cert_desc = {'certificateDescription': {'status': 'ACTIVE', 'certificateArn': NEW_CERT_ARN}}
     boto3_client.describe_certificate.return_value = cert_desc
     handler(event, None)
@@ -166,7 +166,7 @@ def test_job_failed_after_create(boto3_client, event):
 def test_job_failed_after_commit(boto3_client, event):
     """ We should not delete any certificate, but should send a notification """
     event['status'] = 'FAILED'
-    event['statusDetails']['progress'] = 'committed'
+    event['statusDetails']['certificateRotationProgress'] = 'committed'
     handler(event, None)
     confirm_certificate_not_deleted(boto3_client)
     boto3_client.publish.assert_called_once()
@@ -174,7 +174,7 @@ def test_job_failed_after_commit(boto3_client, event):
 def test_job_timed_out_before_create(boto3_client, event):
     """ We should not delete any certificate, but should send a notification """
     event['status'] = 'TIMED_OUT'
-    del event['statusDetails']['progress']
+    del event['statusDetails']['certificateRotationProgress']
     handler(event, None)
     confirm_certificate_not_deleted(boto3_client)
     boto3_client.publish.assert_called_once()
@@ -182,7 +182,7 @@ def test_job_timed_out_before_create(boto3_client, event):
 def test_job_timed_out_after_create(boto3_client, event):
     """ This is a rollback. The new certificate should be deleted """
     event['status'] = 'TIMED_OUT'
-    event['statusDetails']['progress'] = 'created'
+    event['statusDetails']['certificateRotationProgress'] = 'created'
     cert_desc = {'certificateDescription': {'status': 'ACTIVE', 'certificateArn': NEW_CERT_ARN}}
     boto3_client.describe_certificate.return_value = cert_desc
     handler(event, None)
@@ -192,7 +192,7 @@ def test_job_timed_out_after_create(boto3_client, event):
 def test_job_timed_out_after_commit(boto3_client, event):
     """ We should not delete any certificate, but should send a notification """
     event['status'] = 'TIMED_OUT'
-    event['statusDetails']['progress'] = 'committed'
+    event['statusDetails']['certificateRotationProgress'] = 'committed'
     handler(event, None)
     confirm_certificate_not_deleted(boto3_client)
     boto3_client.publish.assert_called_once()


### PR DESCRIPTION
*Issue #, if available:*

#27 

*Description of changes:*

JobExecutionTerminal rule should filter certificate rotation jobs explicity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
