### PR TITLE
Resolve certificate/private-key paths from the live config for Fleet Provisioning devices

### DIFF
--- a/artifacts/effective_config.py
+++ b/artifacts/effective_config.py
@@ -5,28 +5,175 @@
 Greengrass effective configuration
 """
 
+import json
 import os
 import platform
+
 import yaml
 
+# Certificate and private key paths may be recorded with a file URI scheme.
+# Strip it so that the value can be passed to open().
+FILE_SCHEME = 'file://'
+
+# Topic paths of the values we resolve, in both the transaction log and the
+# effective configuration.
+TP_CERTIFICATE_FILE_PATH = ['system', 'certificateFilePath']
+TP_PRIVATE_KEY_PATH = ['system', 'privateKeyPath']
+
+# Greengrass default file names, relative to the Greengrass root path. Used as a
+# last resort when neither the transaction log nor the effective configuration
+# holds a value.
+DEFAULT_CERTIFICATE_FILE_NAME = 'thingCert.crt'
+DEFAULT_PRIVATE_KEY_FILE_NAME = 'privKey.key'
+
 class EffectiveConfig():
-    """ Greengrass effective configuration """
+    """ Greengrass effective configuration.
+
+    Resolves the certificate and private key paths using a three-tier fallback:
+
+      1. The transaction log (config/config.tlog), which holds the authoritative
+         running configuration. This is the only source that is correct on
+         devices provisioned by Fleet Provisioning, where the effective
+         configuration snapshot holds empty values.
+      2. The effective configuration snapshot (config/effectiveConfig.yaml),
+         which is correct on manually provisioned devices.
+      3. The Greengrass defaults, relative to the Greengrass root path.
+    """
     def __init__(self):
         # Get the Greengrass root path from our working directory
         if platform.system() == 'Windows':
             gg_root_path = os.getcwd().split('\\work')[0]
-            file_path = '\\config\\effectiveConfig.yaml'
+            effective_config_path = f'{gg_root_path}\\config\\effectiveConfig.yaml'
+            transaction_log_path = f'{gg_root_path}\\config\\config.tlog'
         else:
             gg_root_path = os.getcwd().split('/work')[0]
-            file_path = '/config/effectiveConfig.yaml'
+            effective_config_path = f'{gg_root_path}/config/effectiveConfig.yaml'
+            transaction_log_path = f'{gg_root_path}/config/config.tlog'
 
-        with open(f'{gg_root_path}{file_path}', encoding='utf-8') as effective_config_file:
-            self._yaml = yaml.safe_load(effective_config_file)
+        self._gg_root_path = gg_root_path
+        self._yaml = self._load_effective_config(effective_config_path)
+        self._transaction_log = self._load_transaction_log(transaction_log_path)
 
     def certificate_file_path(self) -> str:
         """ Certificate file path configuration """
-        return self._yaml['system']['certificateFilePath']
+        return self._resolve(TP_CERTIFICATE_FILE_PATH, DEFAULT_CERTIFICATE_FILE_NAME)
 
     def private_key_path(self) -> str:
         """ Private key path configuration """
-        return self._yaml['system']['privateKeyPath']
+        return self._resolve(TP_PRIVATE_KEY_PATH, DEFAULT_PRIVATE_KEY_FILE_NAME)
+
+    @staticmethod
+    def _load_effective_config(file_path) -> dict:
+        """ Loads the effective configuration snapshot.
+
+        A missing or malformed snapshot is not fatal: the transaction log and the
+        Greengrass defaults remain as sources.
+        """
+        try:
+            with open(file_path, encoding='utf-8') as effective_config_file:
+                loaded = yaml.safe_load(effective_config_file)
+        except (OSError, yaml.YAMLError) as error:
+            print(f'Could not read {file_path}: {repr(error)}.')
+            loaded = None
+
+        return loaded if isinstance(loaded, dict) else {}
+
+    @staticmethod
+    def _load_transaction_log(file_path) -> dict:
+        """ Scans the Greengrass transaction log for the values we resolve.
+
+        The log is newline delimited JSON: one object per line, appended to over
+        the lifetime of the device. Each entry has a timestamp ('TS'), a topic
+        path ('TP') and a value ('V'). Several entries may exist for one topic
+        path, in which case the newest one is current.
+
+        A missing, unreadable or partially malformed log is not fatal: blank and
+        unparseable lines are skipped, and any topic path without a value simply
+        falls through to the next source.
+        """
+        newest = {}
+
+        try:
+            with open(file_path, encoding='utf-8') as transaction_log_file:
+                for line in transaction_log_file:
+                    EffectiveConfig._collect_transaction_log_entry(line, newest)
+        except OSError as error:
+            print(f'Could not read {file_path}: {repr(error)}.')
+
+        return { key: value for key, (_, value) in newest.items() }
+
+    @staticmethod
+    def _collect_transaction_log_entry(line, newest) -> None:
+        """ Keeps the newest non-empty value per topic path of interest """
+        line = line.strip()
+
+        if not line:
+            return
+
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            # Truncated or otherwise malformed line. Greengrass owns this file,
+            # so we skip whatever we don't understand.
+            return
+
+        if not isinstance(entry, dict):
+            return
+
+        topic_path = entry.get('TP')
+        value = entry.get('V')
+        timestamp = entry.get('TS')
+
+        if topic_path not in (TP_CERTIFICATE_FILE_PATH, TP_PRIVATE_KEY_PATH):
+            return
+        if not isinstance(value, str) or not value:
+            return
+        if not isinstance(timestamp, int) or isinstance(timestamp, bool):
+            timestamp = 0
+
+        key = EffectiveConfig._topic_path_key(topic_path)
+
+        # On equal timestamps the later line wins, the log being append only.
+        if key not in newest or timestamp >= newest[key][0]:
+            newest[key] = (timestamp, value)
+
+    @staticmethod
+    def _topic_path_key(topic_path) -> str:
+        """ Dictionary key for a topic path """
+        return '/'.join(topic_path)
+
+    def _resolve(self, topic_path, default_file_name) -> str:
+        """ Resolves a configuration path from the transaction log, else the
+        effective configuration snapshot, else the Greengrass default """
+        value = self._transaction_log.get(EffectiveConfig._topic_path_key(topic_path), '')
+
+        if not value:
+            value = self._from_effective_config(topic_path)
+
+        if not value:
+            value = os.path.join(self._gg_root_path, default_file_name)
+
+        return EffectiveConfig._strip_file_scheme(value)
+
+    def _from_effective_config(self, topic_path) -> str:
+        """ Reads a value from the effective configuration snapshot """
+        node = self._yaml
+
+        for key in topic_path:
+            if not isinstance(node, dict):
+                return ''
+            node = node.get(key)
+
+        return node if isinstance(node, str) else ''
+
+    @staticmethod
+    def _strip_file_scheme(value) -> str:
+        """ Strips a leading file URI scheme, leaving a plain filesystem path.
+
+        Values that are not file URIs, such as the PKCS#11 URIs of an HSM
+        configuration, are returned unchanged.
+        """
+        if value.startswith(FILE_SCHEME):
+            return value[len(FILE_SCHEME):]
+
+        return value

--- a/tests/artifacts/test_effective_config.py
+++ b/tests/artifacts/test_effective_config.py
@@ -5,35 +5,123 @@
 Unit tests for artifacts.effective_config.py
 """
 
+import json
 from effective_config import EffectiveConfig
 
 ROOT_DIR = 'rocinante'
-CONFIG_FILE =\
+
+EFFECTIVE_CONFIG_WITH_PATHS =\
 """
 system:
     certificateFilePath: cartman
     privateKeyPath: stan
 """
 
-def do_load_and_checks(mocker, platform, working_directory, config_path):
-    """ Common steps """
-    platform_system = mocker.patch('effective_config.platform.system', return_value=platform)
-    os_getcwd = mocker.patch('effective_config.os.getcwd', return_value=f'{ROOT_DIR}{working_directory}')
-    file_open = mocker.patch('effective_config.open', mocker.mock_open(read_data=CONFIG_FILE))
+EFFECTIVE_CONFIG_EMPTY_PATHS =\
+"""
+system:
+    certificateFilePath: ""
+    privateKeyPath: ""
+"""
+
+def mock_config_files(mocker, platform_name, working_directory,
+                      effective_config, transaction_log=None):
+    """ Mocks the platform, working directory and config file reads.
+
+    open() is dispatched by file name: the effective configuration snapshot
+    returns `effective_config`; the transaction log returns `transaction_log`,
+    or raises FileNotFoundError when it is None, standing in for an absent log.
+    """
+    mocker.patch('effective_config.platform.system', return_value=platform_name)
+    mocker.patch('effective_config.os.getcwd', return_value=f'{ROOT_DIR}{working_directory}')
+
+    def dispatch(file_path, *args, **kwargs):
+        if str(file_path).endswith('config.tlog'):
+            if transaction_log is None:
+                raise FileNotFoundError(file_path)
+            return mocker.mock_open(read_data=transaction_log)(file_path, *args, **kwargs)
+        return mocker.mock_open(read_data=effective_config)(file_path, *args, **kwargs)
+
+    mocker.patch('effective_config.open', side_effect=dispatch)
+
+def transaction_log(entries):
+    """ Builds a transaction log body from (topic_path, value, timestamp) tuples """
+    lines = [json.dumps({'TS': timestamp, 'TP': topic_path, 'V': value})
+             for topic_path, value, timestamp in entries]
+    return '\n'.join(lines) + '\n'
+
+def test_effective_config_loads_under_linux(mocker):
+    """ Manually provisioned device, Linux: the snapshot value is used """
+    mock_config_files(mocker, 'Linux', '/work', EFFECTIVE_CONFIG_WITH_PATHS)
 
     config = EffectiveConfig()
-
-    platform_system.assert_called_once()
-    os_getcwd.assert_called_once()
-    file_open.assert_called_once_with(f'{ROOT_DIR}{config_path}', encoding='utf-8')
 
     assert config.certificate_file_path() == 'cartman'
     assert config.private_key_path() == 'stan'
 
-def test_effective_config_loads_under_linux(mocker):
-    """ Test under Linux """
-    do_load_and_checks(mocker, 'Linux', '/work', '/config/effectiveConfig.yaml')
-
 def test_effective_config_loads_under_windows(mocker):
-    """ Test under Windows """
-    do_load_and_checks(mocker, 'Windows', '\\work', '\\config\\effectiveConfig.yaml')
+    """ Manually provisioned device, Windows: the snapshot value is used """
+    mock_config_files(mocker, 'Windows', '\\work', EFFECTIVE_CONFIG_WITH_PATHS)
+
+    config = EffectiveConfig()
+
+    assert config.certificate_file_path() == 'cartman'
+    assert config.private_key_path() == 'stan'
+
+def test_transaction_log_overrides_empty_snapshot(mocker):
+    """ Fleet provisioned device: the snapshot holds empty paths, so the newest
+    transaction log entry decides. Stale, blank and malformed lines are ignored. """
+    log = (
+        json.dumps({'TS': 1, 'TP': ['system', 'certificateFilePath'], 'V': ''}) + '\n'
+        + json.dumps({'TS': 100, 'TP': ['system', 'certificateFilePath'], 'V': '/gg/old.crt'}) + '\n'
+        + 'this is not json\n'
+        + '\n'
+        + json.dumps({'TS': 100, 'TP': ['system'], 'V': {'nested': 'ignored'}}) + '\n'
+        + transaction_log([
+            (['system', 'certificateFilePath'], '/gg/thingCert.crt', 200),
+            (['system', 'privateKeyPath'], '/gg/privKey.key', 200),
+        ])
+    )
+    mock_config_files(mocker, 'Linux', '/work', EFFECTIVE_CONFIG_EMPTY_PATHS, log)
+
+    config = EffectiveConfig()
+
+    assert config.certificate_file_path() == '/gg/thingCert.crt'
+    assert config.private_key_path() == '/gg/privKey.key'
+
+def test_file_uri_scheme_is_stripped(mocker):
+    """ A file URI value is reduced to a plain path that open() can use """
+    effective_config = (
+        'system:\n'
+        '    certificateFilePath: file:///x/y.crt\n'
+        '    privateKeyPath: file:///x/y.key\n'
+    )
+    mock_config_files(mocker, 'Linux', '/work', effective_config)
+
+    config = EffectiveConfig()
+
+    assert config.certificate_file_path() == '/x/y.crt'
+    assert config.private_key_path() == '/x/y.key'
+
+def test_greengrass_defaults_when_nothing_configured(mocker):
+    """ Neither source holds a value, so the Greengrass defaults are used """
+    mock_config_files(mocker, 'Linux', '/work', EFFECTIVE_CONFIG_EMPTY_PATHS)
+
+    config = EffectiveConfig()
+
+    assert config.certificate_file_path() == f'{ROOT_DIR}/thingCert.crt'
+    assert config.private_key_path() == f'{ROOT_DIR}/privKey.key'
+
+def test_pkcs11_uris_are_preserved(mocker):
+    """ HSM configuration: PKCS#11 URIs must survive resolution unchanged """
+    effective_config = (
+        'system:\n'
+        "    certificateFilePath: 'pkcs11:object=iotcert;type=cert'\n"
+        "    privateKeyPath: 'pkcs11:object=iotkey;type=private'\n"
+    )
+    mock_config_files(mocker, 'Linux', '/work', effective_config)
+
+    config = EffectiveConfig()
+
+    assert config.certificate_file_path() == 'pkcs11:object=iotcert;type=cert'
+    assert config.private_key_path().startswith('pkcs11:object=')


### PR DESCRIPTION
## Issue
Fixes https://github.com/awslabs/aws-greengrass-labs-certificate-rotator/issues/120

## Problem
`EffectiveConfig` read `system.certificateFilePath` / `privateKeyPath` directly from `effectiveConfig.yaml`. On Fleet-Provisioning-by-claim devices those snapshot values are empty (the real path is only committed to `config.tlog`), so `pki_file.create_csr()` calls `open("")` and rotation fails with `FileNotFoundError`.

## Change
`artifacts/effective_config.py` resolves each path with a three-tier fallback:
1. `config/config.tlog` - the authoritative running config; the newest (`TS`) entry for `["system","certificateFilePath"]` / `["system","privateKeyPath"]` wins.
2. `config/effectiveConfig.yaml` - the snapshot (correct on manually provisioned devices).
3. Greengrass defaults `thingCert.crt` / `privKey.key` under the root path.

A leading `file://` scheme is stripped; PKCS#11 (HSM) URIs pass through unchanged; missing or malformed config files are handled gracefully.

## Behaviour
- Manually provisioned devices: unchanged (snapshot value still used).
- Fleet-provisioned devices: resolve the real path and rotate successfully.
- No public API, recipe, or backend change.

## Tests
Extends `tests/artifacts/test_effective_config.py` (pytest + pytest-mock): Linux/Windows snapshot load, transaction-log override of an empty snapshot (with stale/blank/malformed lines), `file://` stripping, default fallback, and PKCS#11 preservation. All pass locally (`6 passed`).
