### PR TITLE
Bump aws-cdk CLI to 2.1140.0 to match aws-cdk-lib schema

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/jest": "^30",
         "@types/node": "^24.10.1",
-        "aws-cdk": "2.1101.0",
+        "aws-cdk": "2.1140.0",
         "jest": "^30",
         "ts-jest": "^29",
         "ts-node": "^10.9.2",
@@ -1663,9 +1663,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1101.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1101.0.tgz",
-      "integrity": "sha512-5EP+t13OFzE0SaK+KY/di9ZcXQYwnhDtM8kqEMjEvqhj+K3eqtV0DDI1YjthOoVMBAHgZK9juKPqxfwwRprBPQ==",
+      "version": "2.1140.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1140.0.tgz",
+      "integrity": "sha512-myrqWFEby3w+athNRM5EcnKXpby8shR7WwhxtAE853qDPmCggvIZe0wwkUzyuWJdFVD3zP5rzRuATxnnapeXig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1673,9 +1673,6 @@
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
@@ -2780,21 +2777,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "^30",
     "@types/node": "^24.10.1",
-    "aws-cdk": "2.1101.0",
+    "aws-cdk": "2.1140.0",
     "jest": "^30",
     "ts-jest": "^29",
     "ts-node": "^10.9.2",

--- a/cicd/package-lock.json
+++ b/cicd/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/jest": "^30",
         "@types/node": "^24.10.1",
-        "aws-cdk": "2.1101.0",
+        "aws-cdk": "2.1140.0",
         "jest": "^30",
         "ts-jest": "^29",
         "ts-node": "^10.9.2",
@@ -1663,9 +1663,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1101.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1101.0.tgz",
-      "integrity": "sha512-5EP+t13OFzE0SaK+KY/di9ZcXQYwnhDtM8kqEMjEvqhj+K3eqtV0DDI1YjthOoVMBAHgZK9juKPqxfwwRprBPQ==",
+      "version": "2.1140.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1140.0.tgz",
+      "integrity": "sha512-myrqWFEby3w+athNRM5EcnKXpby8shR7WwhxtAE853qDPmCggvIZe0wwkUzyuWJdFVD3zP5rzRuATxnnapeXig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1673,9 +1673,6 @@
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
@@ -2622,21 +2619,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",

--- a/cicd/package.json
+++ b/cicd/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "^30",
     "@types/node": "^24.10.1",
-    "aws-cdk": "2.1101.0",
+    "aws-cdk": "2.1140.0",
     "jest": "^30",
     "ts-jest": "^29",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
The pinned aws-cdk CLI (2.1101.0) supports cloud assembly schema up to 50.x.x, but aws-cdk-lib (2.260/2.262) now emits schema 54.0.0, causing 'cdk synth' to fail in the pipeline. Bump the CLI in backend and cicd to 2.1140.0 (>= the required 2.1127.0) and refresh the lock files.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
